### PR TITLE
Add redirect to test if redirection works on build preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@ to = "https://capi.phil.us/api/redirect/:splat"
 status = 302
 
 [[redirects]]
+from = "/bentest/*"
+to = "https://www.google.com/search?q=:splat"
+status = 302
+
+[[redirects]]
 from = "/faqs/*"
 to = "https://philhelp.zendesk.com/hc/en-us"
 status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,8 @@ to = "https://capi.phil.us/api/redirect/:splat"
 status = 302
 
 [[redirects]]
-from = "/bentest/*"
-to = "https://www.google.com/search?q=:splat"
+from = "/e/*"
+to = "https://enroll.phil.us/landing/:splat"
 status = 302
 
 [[redirects]]


### PR DESCRIPTION
## Issue with Asana link

Allow redirection from [https://phil.us/e/:token](https://phil.us/en/:token) → [https://enroll.phil.us/landing/:token](https://enroll.phil.us/landing/:token)

* [Asana link](https://app.asana.com/0/1202097064003005/1202207255077030/f)

## Usage Changes

Navigating to https://phil.us/e/:token will automatically redirect to https://enroll.phil.us/landing/:token