### PR TITLE
Phil enroll redirection

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,28 @@
+# general redirection
 [[redirects]]
 from = "/r/*"
 to = "https://capi.phil.us/api/redirect/:splat"
 status = 302
 
+
+# phil-enroll redirection
 [[redirects]]
 from = "/e/*"
 to = "https://enroll.phil.us/landing/:splat"
 status = 302
 
+[[redirects]]
+from = "/stage/e/*"
+to = "https://enroll.stage.phil.us/landing/:splat"
+status = 302
+
+[[redirects]]
+from = "/dev/e/*"
+to = "https://enroll.dev.phil.us/landing/:splat"
+status = 302
+
+
+# faqs redirection
 [[redirects]]
 from = "/faqs/*"
 to = "https://philhelp.zendesk.com/hc/en-us"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@ to = "https://capi.phil.us/api/redirect/:splat"
 status = 302
 
 [[redirects]]
+from = "/bentest/*"
+to = "https://www.google.com/search?q=:splat"
+status = 302
+
+[[redirects]]
 from = "/faqs/*"
 to = "https://philhelp.zendesk.com/hc/en-us"
 status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,8 @@ to = "https://capi.phil.us/api/redirect/:splat"
 status = 302
 
 [[redirects]]
-from = "/bentest/*"
-to = "https://www.google.com/search?q=:splat"
+from = "/e/*"
+to = "https://enroll.phil.us/landing/:splat"
 status = 302
 
 [[redirects]]


### PR DESCRIPTION
## Issue with Asana link

Allows testing redirection to dev and stage environments

* [Asana link](https://app.asana.com/0/1202097064003005/1202207255077030/f)

## Usage Changes

phil.us/dev/e/ redirects to enroll.dev.phil.us/landing/

phil.us/stage/e/ redirects to enroll.stage.phil.us/landing/